### PR TITLE
Latest versions of Facebook oauth api return JSON responses, which didn't work with pac4j v1.8.2.

### DIFF
--- a/tynamo-federatedaccounts-pac4jbasedoauth/pom.xml
+++ b/tynamo-federatedaccounts-pac4jbasedoauth/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.pac4j</groupId>
 			<artifactId>pac4j-oauth</artifactId>
-			<version>1.8.2</version>
+			<version>2.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/pages/Pac4jOauth.java
+++ b/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/pages/Pac4jOauth.java
@@ -53,6 +53,8 @@ public class Pac4jOauth extends AbstractOauthPage {
 		J2EContext context = new J2EContext(httpRequest, httpResponse);
 		clientName = eventContext.get(String.class, 1);
 		Pac4jOauthClient client = oauthClientLocator.getClient(clientName);
+		client.setReadTimeout(20000);
+		client.setConnectTimeout(20000);	
 		if (eventContext.getCount() > 3) {
 			String action = eventContext.get(String.class, 2);
 			// pass along this redirectUrl

--- a/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/pages/Pac4jOauth.java
+++ b/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/pages/Pac4jOauth.java
@@ -54,7 +54,7 @@ public class Pac4jOauth extends AbstractOauthPage {
 		clientName = eventContext.get(String.class, 1);
 		Pac4jOauthClient client = oauthClientLocator.getClient(clientName);
 		client.setReadTimeout(20000);
-		client.setConnectTimeout(20000);	
+		client.setConnectTimeout(20000);
 		if (eventContext.getCount() > 3) {
 			String action = eventContext.get(String.class, 2);
 			// pass along this redirectUrl

--- a/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClient.java
+++ b/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClient.java
@@ -9,7 +9,7 @@ import org.pac4j.oauth.credentials.OAuth20Credentials;
 import org.pac4j.oauth.credentials.OAuth10Credentials;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.HttpAction;
-
+import org.pac4j.oauth.config.OAuth20Configuration;
 
 /**
  * Wrapper class for different versions of oauth client instances.
@@ -44,7 +44,23 @@ public class Pac4jOauthClient {
          }
          return client10.getName();
      }
- 
+
+     public void setReadTimeout(final int timeout) {
+         if (client20 != null) {
+             client20.getConfiguration().setReadTimeout(timeout);
+         } else {
+             client10.getConfiguration().setReadTimeout(timeout);;
+         }
+     }
+
+     public void setConnectTimeout(final int timeout) {
+         if (client20 != null) {
+             client20.getConfiguration().setConnectTimeout(timeout);
+         } else {
+             client10.getConfiguration().setConnectTimeout(timeout);;
+         }
+     }
+
      public void setCallbackUrl(final String callbackUrl) {
         if (client20 != null) {
              client20.setCallbackUrl(callbackUrl);

--- a/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClient.java
+++ b/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClient.java
@@ -1,0 +1,78 @@
+package org.tynamo.security.federatedaccounts.pac4j.services;
+
+import org.pac4j.oauth.client.OAuth20Client;
+import org.pac4j.oauth.client.OAuth10Client;
+
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.oauth.credentials.OAuth20Credentials;
+import org.pac4j.oauth.credentials.OAuth10Credentials;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.HttpAction;
+
+
+/**
+ * Wrapper class for different versions of oauth client instances.
+ * BaseOAuthCLient has been removed from Pac4j, so now we have to explicitly deal with two distinct versions of oauth clients.
+ * This class wraps client instances and allows to avoid code duplication in Pac4jOauth.onOauthActivate() method.
+ */
+public class Pac4jOauthClient {
+
+     private OAuth20Client<?> client20;
+     private OAuth10Client<?> client10;
+
+     public Pac4jOauthClient(OAuth20Client<?> client20) {
+         this.client20 = client20;
+         this.client10 = null;
+     }
+
+     public Pac4jOauthClient(OAuth10Client<?> client10) {
+         this.client20 = null;
+         this.client10 = client10;
+     }
+
+     public Object instance() {
+         if (client20 != null) {
+             return client20;
+         }
+         return client10;   
+     }
+
+     public String getName() {
+         if (client20 != null) {
+             return client20.getName();
+         }
+         return client10.getName();
+     }
+ 
+     public void setCallbackUrl(final String callbackUrl) {
+        if (client20 != null) {
+             client20.setCallbackUrl(callbackUrl);
+         } else {
+             client10.setCallbackUrl(callbackUrl);
+         }
+     }
+
+     public String getCallbackUrl() {
+         if (client20 != null) {
+             return client20.getCallbackUrl();
+         }
+         return client10.getCallbackUrl();
+     }
+
+     public String getRedirectionUrl(final WebContext context) throws HttpAction {
+         if (client20 != null) {
+             return client20.getRedirectAction(context).getLocation();
+         }
+         return client10.getRedirectAction(context).getLocation();
+     }
+
+     public final CommonProfile getUserProfile(final WebContext context) throws HttpAction {
+         if (client20 != null) {
+             OAuth20Credentials credentials = client20.getCredentials(context);
+             return client20.getUserProfile(credentials, context);
+         }
+         OAuth10Credentials credentials = client10.getCredentials(context);
+         return client10.getUserProfile(credentials, context); 
+     }
+}

--- a/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClientLocator.java
+++ b/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClientLocator.java
@@ -1,12 +1,10 @@
 package org.tynamo.security.federatedaccounts.pac4j.services;
 
-import org.pac4j.oauth.client.BaseOAuthClient;
-
 public interface Pac4jOauthClientLocator {
 	enum SupportedClient {
 		facebook, dropbox, github, google2, linkedin2, twitter, windowslive, wordpress, yahoo
 	}
 
-	public BaseOAuthClient getClient(String clientName);
+	public Pac4jOauthClient getClient(String clientName);
 
 }

--- a/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClientLocatorImpl.java
+++ b/tynamo-federatedaccounts-pac4jbasedoauth/src/main/java/org/tynamo/security/federatedaccounts/pac4j/services/Pac4jOauthClientLocatorImpl.java
@@ -1,7 +1,6 @@
 package org.tynamo.security.federatedaccounts.pac4j.services;
 
 import org.apache.tapestry5.ioc.annotations.Symbol;
-import org.pac4j.oauth.client.BaseOAuthClient;
 import org.pac4j.oauth.client.DropBoxClient;
 import org.pac4j.oauth.client.FacebookClient;
 import org.pac4j.oauth.client.GitHubClient;
@@ -72,27 +71,27 @@ public class Pac4jOauthClientLocatorImpl implements Pac4jOauthClientLocator {
 	}
 
 	@Override
-	public BaseOAuthClient<?> getClient(String clientName) {
+	public Pac4jOauthClient getClient(String clientName) {
 		SupportedClient client = SupportedClient.valueOf(clientName);
 		switch (client) {
 		case dropbox:
-			return new DropBoxClient(dropboxClientId, dropboxClientSecret);
+			return new Pac4jOauthClient(new DropBoxClient(dropboxClientId, dropboxClientSecret));
 		case facebook:
-			return new FacebookClient(facebookClientId, facebookClientSecret);
+			return new Pac4jOauthClient(new FacebookClient(facebookClientId, facebookClientSecret));
 		case github:
-			return new GitHubClient(githubClientId, githubClientSecret);
+			return new Pac4jOauthClient(new GitHubClient(githubClientId, githubClientSecret));
 		case google2:
-			return new Google2Client(googleClientId, googleClientSecret);
+			return new Pac4jOauthClient(new Google2Client(googleClientId, googleClientSecret));
 		case linkedin2:
-			return new LinkedIn2Client(linkedinClientId, linkedinClientSecret);
+			return new Pac4jOauthClient(new LinkedIn2Client(linkedinClientId, linkedinClientSecret));
 		case twitter:
-			return new TwitterClient(twitterClientId, twitterClientSecret);
+			return new Pac4jOauthClient(new TwitterClient(twitterClientId, twitterClientSecret));
 		case windowslive:
-			return new WindowsLiveClient(windowsliveClientId, windowsliveClientSecret);
+			return new Pac4jOauthClient(new WindowsLiveClient(windowsliveClientId, windowsliveClientSecret));
 		case wordpress:
-			return new WordPressClient(wordpressClientId, wordpressClientSecret);
+			return new Pac4jOauthClient(new WordPressClient(wordpressClientId, wordpressClientSecret));
 		case yahoo:
-			return new YahooClient(yahooClientId, yahooClientSecret);
+			return new Pac4jOauthClient(new YahooClient(yahooClientId, yahooClientSecret));
 		default:
 			throw new IllegalArgumentException("Client " + clientName + " is not one of the supported clients "
 				+ SupportedClient.values());


### PR DESCRIPTION
I propose to set pac4j dependency to v2.0.0, which is up to date with latest changes in many identity providers (including Facebook and actually makes Facebook authentication work). The code had to be also adjusted to correcly integrate with pac4j v2.0.0.

I have tested only Facebook integration (I have no possibility to test other clients yet). Kalle, could you please accommodate these changes under your main project? Thank you!